### PR TITLE
Adding the possibility to have a configuration file

### DIFF
--- a/capture.sh
+++ b/capture.sh
@@ -25,17 +25,32 @@
 
 # Needs ffmpeg, ghostscript, imagemagick
 
+configuration_file=${HOME}/.MacBlackBox
+if [ -f $configuration_file ]; then
+	source $configuration_file
+fi 
+
 # How long to wait between screenshots
-snapshot_interval_seconds=10
+snapshot_interval_seconds=${snapshot_interval_seconds-10}
 
 # How many snapshots per second in the hourly movies
-snapshots_per_second=2
+snapshots_per_second=${snapshots_per_second-2}
 
 # How long to keep the hourly videos, in days
-keep_video_days=120
+keep_video_days=${keep_video_days-120}
+
+# Location of the captures.  Captures are saved into this directory.  Hourly movies to the parent directory.
+videos_location=${videos_location-~/MacBlackBox}
+
+if [ -n "$show_config" -a "$show_config" != "0" ]; then
+	echo Capturing a screenshot ever $snapshot_interval_seconds seconds
+	echo Creating videos with $snapshots_per_second snapshots per second 
+	echo \($((snapshots_per_second*snapshot_interval_seconds)) real life seconds per video second\)
+	echo Keeping videos for $keep_video_days days, in $videos_location
+fi
 
 # Change this as you wish.  Captures are saved into this directory.  Hourly movies to the parent directory.
-cd ~/MacBlackBox/captures
+cd ${videos_location}/captures
 
 previous_hour=$(date +%Y%m%d%H)
 previous_day=$(date +%Y%m%d)


### PR DESCRIPTION
I didn't want to have to stash my own configuration for every change.

The config file is loaded as a bash file, and can contain values for
the existing configurable properties:
- `snapshot_interval_seconds`
- `snapshots_per_second`
- `keep_video_days`
- `videos_location` (one level below the "captures" folder)

And an additional `show_config` variable which triggers, if set to
something different than 0, the display of a summary of the
configuration values.
