### PR TITLE
Added safe file name handling for ffmpeg concat command.

### DIFF
--- a/capture.sh
+++ b/capture.sh
@@ -104,7 +104,7 @@ do
 			# Only create the movie if we have files for the previous day
 			if ls ${previous_day}*_${i}.jpg 1> /dev/null 2>&1
 			then
-				(nice ffmpeg -f concat -i <(for f in $videos_location/$previous_day*_$i.mp4; do echo "file '$f'"; done) -c copy $videos_location/${previous_day}_${i}.mp4; rm $videos_location/$previous_day??_$i.mp4) &
+				(nice ffmpeg -f concat -i -safe 0 <(for f in $videos_location/$previous_day*_$i.mp4; do echo "file '$f'"; done) -c copy $videos_location/${previous_day}_${i}.mp4; rm $videos_location/$previous_day??_$i.mp4) &
 			fi
 		done
 		previous_day=$current_day


### PR DESCRIPTION
The later versions of concat moan about having an 'unsafe file name' i.e.

ffmpeg version 3.4 Copyright (c) 2000-2017 the FFmpeg developers
  built with Apple LLVM version 9.0.0 (clang-900.0.37)
  configuration: --prefix=/usr/local/Cellar/ffmpeg/3.4 --enable-shared --enable-pthreads --enable-version3 --enable-hardcoded-tables --enable-avresample --cc=clang --host-cflags= --host-ldflags= --enable-gpl --enable-libmp3lame --enable-libx264 --enable-libxvid --enable-opencl --enable-videotoolbox --disable-lzma
  libavutil      55. 78.100 / 55. 78.100
  libavcodec     57.107.100 / 57.107.100
  libavformat    57. 83.100 / 57. 83.100
  libavdevice    57. 10.100 / 57. 10.100
  libavfilter     6.107.100 /  6.107.100
  libavresample   3.  7.  0 /  3.  7.  0
  libswscale      4.  8.100 /  4.  8.100
  libswresample   2.  9.100 /  2.  9.100
  libpostproc    54.  7.100 / 54.  7.100
[concat @ 0x7fb016800a00] Unsafe file name '/Users/.../MacBlackBox/2017103010_1.mp4'
/dev/fd/63: Operation not permitted

This causes MacBlackBox to delete the previous day's videos. Adding -safe 0 to it makes the error go away and returns MacBlackBox to working in the prescribed manner.